### PR TITLE
Prevent Extra Refreshing of Untagged Shows

### DIFF
--- a/plex/plex-scan-new.sh
+++ b/plex/plex-scan-new.sh
@@ -70,9 +70,10 @@ do
         $LD_LIBRARY_PATH/Plex\ Media\ Scanner --scan --refresh --section "$MOVIESECTION" --directory "$FOLDER" | tee -a "$LOGFILE"
     elif [[  $FOLDER == "$TVLIBRARY"* ]]; then
         echo "$(date "+%d.%m.%Y %T") Plex scan TV folder: $FOLDER" | tee -a "$LOGFILE"
-        $LD_LIBRARY_PATH/Plex\ Media\ Scanner --scan --refresh --section "$TVSECTION" --directory "$FOLDER" | tee -a "$LOGFILE"
+        $LD_LIBRARY_PATH/Plex\ Media\ Scanner --scan --section "$TVSECTION" --directory "$FOLDER" | tee -a "$LOGFILE"
     fi
 done
+$LD_LIBRARY_PATH/Plex\ Media\ Scanner --refresh --section "$TVSECTION" | tee -a "$LOGFILE"
 echo "$(date "+%d.%m.%Y %T") Plex scan finished in $(($(date +'%s') - $startplexscan)) seconds" | tee -a "$LOGFILE"
 
 echo "$(date "+%d.%m.%Y %T") Scan completed in $(($(date +'%s') - $start)) seconds" | tee -a "$LOGFILE"


### PR DESCRIPTION
There is currently an issue with the TV Scanner that causes untagged shows to be scanned along with a scan targeted to a particular directory. The easy way to fix this is to move the refresh outside of the scan loop and do a generic refresh of the entire library.

This is not an issue if there is only one directory being scanned, but if you have 10 folders being scanned and say 10 shows untagged, that results in 110 refresh calls due to the untagged shows. By running the refresh after the scan you end up with 20 calls, the sum of the folders and the untagged.

I have raised and documented this issue here:
https://forums.plex.tv/discussion/224957/command-line-scanner-and-partial-refresh/p1